### PR TITLE
fix fetchsvn

### DIFF
--- a/lib/overlay.nix
+++ b/lib/overlay.nix
@@ -85,7 +85,7 @@ builtinsOverlay // {
 in genFetcherOverlay fetcherSuperPkgs fetchers // {
   bazaar = wrapInsecureArgBin super.bazaar "bzr" "-Ossl.cert_reqs=none";
   mercurial = wrapInsecureArgBin super.mercurial "hg" "--insecure";
-  subversion = wrapInsecureArgBin super.mercurial "svn" "--trust-server-cert";
+  subversion = wrapInsecureArgBin super.subversion "svn" "--non-interactive\\ --trust-server-cert";
 
   fetchs3 = unsafeFetcher "fetchs3" "the secret access key and session token will be stored in the Nix store";
   fetchsvnssh = unsafeFetcher "fetchsvnssh" "the SSH user and password will be stored in the Nix store";


### PR DESCRIPTION
I did some debugging on how to actually set the ca file.

Basically, there's this setting called `ssl-authority-files`, needs to be set to a ca cert bundle. This setting is part of the `[global]` section of the `servers` file. This file can be placed in `/etc/subversion` or `$HOME/.subversion`.

Since we can't really write to either of those, it looks like we either have to ignore these errors or patch subversion to look in the nix store.