### PR TITLE
fix extracting old style hashes

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -573,7 +573,7 @@ hash_from_err() {
   # The hash mismatch error message has changed in version 2.2 of Nix, swapping the order of the reported hashes.
   # https://github.com/NixOS/nix/commit/5e6fa9092fb5be722f3568c687524416bc746423
   local head_or_tail=$([[ $err == *'instead of the expected hash'* ]] && echo head || echo tail)
-  if ! actual_hash=$(grep --extended-regexp --only-matching "[a-z0-9]\{${actual_hash_size}\}|${hash_algo}-[A-Za-z0-9/+=]+" <<< "$err" > >($head_or_tail -1)); then
+  if ! actual_hash=$(grep --extended-regexp --only-matching "[a-z0-9]{${actual_hash_size}}|${hash_algo}-[A-Za-z0-9/+=]+" <<< "$err" > >($head_or_tail -1)); then
     (( debug )) && [[ -n $out ]] && printf '%s\n' "$out" >&2
     [[ -n $err ]] && sed '/./,$!d' <<< "$err" >&2
     exit 1


### PR DESCRIPTION
since the changes to accomodate the new hash format
from the newer nix-daemon, the old style hashes have
not been parsed correctly. This fixes nix-prefetch
for handling these types of errors:

```
hash mismatch in fixed-output derivation '/nix/store/3lp6m6wyc117nmam1wmfcz366hb45ll6-source':
  wanted: sha256:0000000000000000000000000000000000000000000000000000
  got:    sha256:0032misdkvw2k1vs9dg17vzfn35m0i1839ls8y5jj6aq0pb9x1dl
error: build of '/nix/store/l7h3bbm2fdkqnja9v5rag97dg1ym4z6j-source.drv' failed
```

see discussion here: https://github.com/msteen/nix-prefetch/commit/2722cda48ab3f4795105578599b29fc99518eff4