### PR TITLE
Fix input_type regex for macOS systems

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -425,7 +425,7 @@ done
 
 handle_common
 
-[[ $input_type =~ ^(|nix|json|shell)$ ]] || die "Unsupported input type '${input_type}'."
+[[ $input_type =~ ^(nix|json|shell)?$ ]] || die "Unsupported input type '${input_type}'."
 [[ $output_type =~ ^(nix|json|shell|raw)$ ]] || die "Unsupported output type '${output_type}'."
 
 if [[ -v fetcher ]]; then


### PR DESCRIPTION
Somehow, nix's bash on macOS systems does not like regexes of the form `(|nix|json)`. Instead, rewrite it as `(nix|json)?` - this fixes #14, restoring operation on macOS and should be functionally equivalent.
