### PR TITLE
src/main.sh: Add --experimental-features and --extra-experimental-features support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.2
+
+- The main script now defaults to pass to Nix `--extra-experimental-features` instead of `--experimental-features` to pay respect to the environment configuration.
+- Add `--experimental-features` and `--extra-experimental-features` flags to allow temporary configuration overriding. One use case is to enable `builtins.getFlake` when not globally enabled.
+
 ## 0.4.1
 
 - More compatible empty check in regex.

--- a/contrib/nix-prefetch-completion.bash
+++ b/contrib/nix-prefetch-completion.bash
@@ -21,7 +21,8 @@ _nix_prefetch() {
   # Indenting with spaces is required to still make " $prev_word " work.
   local params='
     -f --file -A --attr -E --expr -i --index -F --fetcher --arg --argstr -I --option
-    -t --type --hash-algo -h --hash --input --output --eval '
+    -t --type --hash-algo -h --hash --input --output --eval
+    --experimental-features --extra-experimental-features '
   local flags=' -s --silent -q --quiet -v --verbose -vv --debug -l --list --version ' flag
   for flag in --fetchurl --force-https --print-urls --print-path --compute-hash --check-store --autocomplete --help --deep; do
     flags+=" --no-${flag#--} $flag "

--- a/contrib/nix-prefetch-completion.zsh
+++ b/contrib/nix-prefetch-completion.zsh
@@ -21,6 +21,7 @@ _nix_prefetch() {
   local params=(
     '-f' '--file' '-A' '--attr' '-E' '--expr' '-i' '--index' '-F' '--fetcher' '--arg' '--argstr' '-I' '--option'
     '-t' '--type' '--hash-algo' '-h' '--hash' '--input' '--output' '--eval'
+    '--experimental-features' '--extra-experimental-features'
   )
   local flags=( -s --silent -q --quiet -v --verbose -vv --debug -l --list --version ) flag
   for flag in --fetchurl --force-https --print-urls --print-path --compute-hash --check-store --autocomplete --help --deep; do

--- a/doc/nix-prefetch.1.asciidoc
+++ b/doc/nix-prefetch.1.asciidoc
@@ -18,6 +18,7 @@ nix-prefetch - Prefetch any fetcher function call, e.g. package sources
               [*--input* <input-type>] [*--output* <output-type>] [*--print-urls*] [*--print-path*]
               [*--compute-hash*] [*--check-store*] [*-s* | *--silent*] [*-q* | *--quiet*] [*-v* | *--verbose*] [*-vv* | *--debug*] ...
               ([*-f* | *--file*] <file> | [*-A* | *--attr*] <attr> | [*-E* | *--expr*] <expr> | <url>) [<hash>]
+              [ *--experimental-features* | *--extra-experimental-features* ]
               [*--help* | *--autocomplete* | *--eval* <expr>]
               [*--*] [*--<name>* ((*-f* | *--file*) <file> | (*-A* | *--attr*) <attr> | (*-E* | *--expr*) <expr> | <str>)] ...
  *nix-prefetch* [(*-f* | *--file*) <file>] [*--deep*] [*-s* | *--silent*] [*-v* | *--verbose*] [*-vv* | *--debug*] ... (*-l* | *--list*)
@@ -132,6 +133,12 @@ and can placed both before and after the parameters.
 
 *--deep*::
   Rather than only listing the top-level fetchers, deep search Nixpkgs for fetchers (slow).
+
+*--experimental-features*::
+  Set the Nix experimental-features setting.
+
+*--extra-experimental-features*::
+  Append to the Nix experimental-features setting.
 
 *-s*, *--silent*::
   No output to 'stderr'.


### PR DESCRIPTION
*   Default to using --extra-experimental-features
    instead of --experimental-features
    to show respect to the environment configuration.

*   Add flags --extra-experimental-features and --experimental-features
    to allow manual specification to the experimental-features setting
    (e.g. use `builtins.getFlake` when not globally enabled).

Fixes #35 